### PR TITLE
dev-ada/*: remove unsupported ADA_TARGET gnat_2016, add gnat_202{0,1}.

### DIFF
--- a/dev-ada/ada-pretty/ada-pretty-1.0.0.ebuild
+++ b/dev-ada/ada-pretty/ada-pretty-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-ADA_COMPAT=( gnat_201{6,7,8,9} )
+ADA_COMPAT=( gnat_201{7,8,9} gnat_202{0,1} )
 
 inherit ada multiprocessing
 

--- a/dev-ada/matreshka/matreshka-20.1.ebuild
+++ b/dev-ada/matreshka/matreshka-20.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-ADA_COMPAT=( gnat_201{6,7,8,9} )
+ADA_COMPAT=( gnat_201{7,8,9} gnat_202{0,1} )
 inherit ada multiprocessing
 MYP=${PN}-${PV}
 

--- a/dev-ada/protobuf/protobuf-1.0.0.ebuild
+++ b/dev-ada/protobuf/protobuf-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-ADA_COMPAT=( gnat_201{6,7,8,9} )
+ADA_COMPAT=( gnat_201{7,8,9} gnat_202{0,1} )
 
 inherit ada multiprocessing
 


### PR DESCRIPTION
Many errors before build. GNAT Community 2016 is not supported on current Gentoo.
```
emerge -p dev-ada/matreshka
```
output:
```
Calculating dependencies / * ERROR: dev-ada/matreshka-20.1::ada-overlay failed (depend phase):
 *   Invalid implementation in ADA_COMPAT: gnat_2016
 * 
 * Call stack:
 *               ebuild.sh, line 645:  Called source '/var/db/repos/ada-overlay/dev-ada/matreshka/matreshka-20.1.ebuild'
 *   matreshka-20.1.ebuild, line   7:  Called inherit 'ada' 'multiprocessing'
 *               ebuild.sh, line 329:  Called __qa_source '/var/db/repos/gentoo/eclass/ada.eclass'
 *               ebuild.sh, line 114:  Called source '/var/db/repos/gentoo/eclass/ada.eclass'
 *              ada.eclass, line 346:  Called _ada_single_set_globals
 *              ada.eclass, line 285:  Called _ada_set_impls
 | *              ada.eclass, line 126:  Called _ada_impl_supported 'gnat_2016'
 *              ada.eclass, line  94:  Called die
 * The specific snippet of code:
 *   			die "Invalid implementation in ADA_COMPAT: ${impl}"
 * 
 * If you need support, post the output of `emerge --info '=dev-ada/matreshka-20.1::ada-overlay'`,
 * the complete build log and the output of `emerge -pqv '=dev-ada/matreshka-20.1::ada-overlay'`.
 * Working directory: '/usr/lib/python3.9/site-packages'
 * S: '/var/tmp/portage/dev-ada/matreshka-20.1/work/matreshka-20.1'
... done!
```
Fix - remove gnat_2016, add new gnat_202{0,1} ada targets.